### PR TITLE
reset-to-default-ant script: don't switch when in thunderstorm mode

### DIFF
--- a/docs/reset-to-default-antennas-when-no-users-online.txt
+++ b/docs/reset-to-default-antennas-when-no-users-online.txt
@@ -10,6 +10,6 @@ Schedule antenna switching using cron
  chmod u+rx /etc/cron.d/reset-to-default-antennas-when-no-users-online
 
 This will check every 15 minutes are there users online. If there are no
-users online, antenna will be switchd to default. Default antenna is
+users online, antenna will be switched to default. Default antenna is
 defined in /usr/local/bin/reset-to-default-antennas-when-no-users-online
 script. Change it as needed.

--- a/extensions/ant_switch/ant_switch.js
+++ b/extensions/ant_switch/ant_switch.js
@@ -169,7 +169,8 @@ function ant_switch_config_html()
    ext_admin_config(ant_switch_ext_name, 'Antenna switch',
       w3_div('id-ant_switch w3-text-teal w3-hide', '<b>Antenna switch configuration</b>' + '<hr>' +
          w3_div('',
-            w3_div('','If antenna switching is denied then users cannot switch antennas. <br>' +
+            w3_div('', 'Version: 19 Feb 2022 <br><br>' +
+               'If antenna switching is denied then users cannot switch antennas. <br>' +
                'Admin can always switch antennas, either from a connection on the local network, or from the <br>' +
                'KiwiSDR ssh root console using the script: <i>/root/extensions/ant_switch/frontend/ant-switch-frontend</i> <br>' +
                'The last option allows anyone connecting using a user password to switch antennas. <br>' +

--- a/scripts/reset-to-default-antennas-when-no-users-online
+++ b/scripts/reset-to-default-antennas-when-no-users-online
@@ -64,8 +64,14 @@ PORT=`$JQEXEC .port $ADMINJSON`
 STATUSURL="http://127.0.0.1:$PORT/status"
 
 FORBIDSWITCH=`$JQEXEC .ant_switch.denyswitching $KIWIJSON`
-if [ "$FORBIDSWITCH" = "1" ]; then
+if [ "$FORBIDSWITCH" != "0" ]; then
 	echo "Antenna switching denied by configuration, not switching."
+	exit 1
+fi
+
+THUNDERSTORM=`$JQEXEC .ant_switch.thunderstorm $KIWIJSON`
+if [ "$THUNDERSTORM" == "1" ]; then
+	echo "Antenna switching denied by thunderstorm mode, not switching."
 	exit 1
 fi
 


### PR DESCRIPTION
Also, allow for denyswitching values other than just [0,1]